### PR TITLE
Log compiler output atomically and only on debug mode

### DIFF
--- a/builder/src/Reporting.hs
+++ b/builder/src/Reporting.hs
@@ -44,6 +44,8 @@ import qualified Reporting.Doc as D
 import qualified Reporting.Exit as Exit
 import qualified Reporting.Exit.Help as Help
 
+import qualified Ext.Common
+
 
 
 -- STYLE
@@ -204,7 +206,7 @@ detailsLoop chan state@(DState total _ _ _ _ built _) =
           detailsLoop chan =<< detailsStep dmsg state
 
         Nothing ->
-          putStrLn $ clear (toBuildProgress total total) $
+          Ext.Common.debug $ clear (toBuildProgress total total) $
             if built == total
             then "Dependencies ready!"
             else "Dependency problem!"
@@ -242,7 +244,7 @@ detailsStep msg (DState total cached rqst rcvd failed built broken) =
       putTransition (DState total (cached + 1) rqst rcvd failed built broken)
 
     DRequested ->
-      do  when (rqst == 0) (putStrLn "Starting downloads...\n")
+      do  when (rqst == 0) (Ext.Common.debug "Starting downloads...\n")
           return (DState total cached (rqst + 1) rcvd failed built broken)
 
     DReceived pkg vsn ->
@@ -347,7 +349,7 @@ buildLoop chan done =
             !message = toFinalMessage done result
             !width = 12 + length (show done)
           in
-          putStrLn $
+          Ext.Common.debug $
             if length message < width
             then '\r' : replicate width ' ' ++ '\r' : message
             else '\r' : message
@@ -390,7 +392,7 @@ reportGenerate style names output =
     Terminal mvar ->
       do  readMVar mvar
           let cnames = fmap ModuleName.toChars names
-          putStrLn ('\n' : toGenDiagram cnames output)
+          Ext.Common.debug ('\n' : toGenDiagram cnames output)
 
 
 toGenDiagram :: NE.List [Char] -> FilePath -> [Char]
@@ -430,8 +432,11 @@ vbottom = if isWindows then '+' else '┘'
 
 
 putStrFlush :: String -> IO ()
-putStrFlush str =
-  hPutStr stdout str >> hFlush stdout
+putStrFlush =
+  -- elm-dev: 
+  --    This used to print strings without a new line in the original compiler.
+  --    However, contiously writing to the same line doesn't work well in a concurrency setting.
+  Ext.Common.debug
 
 
 

--- a/builder/src/Reporting/Exit/Help.hs
+++ b/builder/src/Reporting/Exit/Help.hs
@@ -23,6 +23,7 @@ import Reporting.Doc ((<+>))
 import qualified Reporting.Doc as D
 import qualified Reporting.Error as Error
 
+import qualified Ext.Common
 
 
 -- REPORT
@@ -130,7 +131,9 @@ toStderr doc =
 
 toHandle :: Handle -> D.Doc -> IO ()
 toHandle handle doc =
-  do  isTerminal <- hIsTerminalDevice handle
-      if isTerminal
-        then D.toAnsi handle doc
-        else hPutStr handle (toString doc)
+  Ext.Common.withPrintLockIfDebug handle (\_ -> do
+    isTerminal <- hIsTerminalDevice handle
+    if isTerminal
+      then D.toAnsi handle doc
+      else hPutStr handle (toString doc)
+  )

--- a/ext-common/Ext/Common.hs
+++ b/ext-common/Ext/Common.hs
@@ -10,7 +10,7 @@ import Control.Concurrent.MVar
 import qualified Data.List as List
 import Text.Read (readMaybe)
 import System.IO.Unsafe (unsafePerformIO)
-import System.IO (hFlush, hPutStr, hPutStrLn, stderr, stdout, hClose, openTempFile)
+import System.IO (Handle, hFlush, hPutStr, hPutStrLn, stderr, stdout, hClose, openTempFile)
 import System.Exit (exitFailure)
 import qualified System.FilePath as FP
 import qualified System.Directory as Dir
@@ -132,6 +132,15 @@ withDebug io = do
 {-# NOINLINE printLock #-}
 printLock :: MVar ()
 printLock = unsafePerformIO $ newMVar ()
+
+
+withPrintLockIfDebug :: Handle -> (() -> IO ()) -> IO ()
+withPrintLockIfDebug handle fn = do 
+  debugMode <- isDebug
+  if debugMode then 
+    withMVar printLock (\_ -> fn () >> hPutStr handle "\n" >> hFlush handle)
+  else
+    pure ()
 
 
 {- Print debugging in a concurrent setting can be painful sometimes due to output

--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -30,7 +30,7 @@ import qualified Elm.Details
 import qualified Elm.ModuleName
 import qualified Elm.ModuleName as ModuleName
 import qualified Elm.String
-import qualified Ext.Common as Maybe
+import Ext.Common (debug)
 import Json.Encode ((==>))
 import qualified Json.Encode
 import qualified Json.String
@@ -71,8 +71,7 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
   case mSource of
     Left err ->
       do
-        print "There was an error reading the source"
-        print err
+        debug $ "There was an error reading the source: \n " ++ show err
         pure Json.Encode.null
     Right (Compile.Artifacts modul typeMap localGraph) -> do
       let found =
@@ -82,7 +81,7 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
       case found of
         FoundNothing ->
           do
-            print "Found nothing :("
+            debug "Found nothing :("
             pure (encodeSearchResult found)
         FoundExpr expr ->
           do
@@ -90,13 +89,13 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
             case locationDetails of
               Nothing ->
                 do
-                  print "Nothing found"
-                  print found
+                  debug "Nothing found"
+                  debug $ show found
                   pure (encodeSearchResult found)
               Just (Local localName) ->
                 do
-                  print "Found local"
-                  print found
+                  debug "Found local"
+                  debug $ show found
                   pure (encodeSearchResult found)
               Just (External canMod name) ->
                 do
@@ -105,8 +104,8 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
                   case lookupModulePath details canMod of
                     Nothing ->
                       do
-                        print "Could not find path"
-                        print found
+                        debug "Could not find path"
+                        debug $ show found
                         pure (encodeSearchResult found)
                     Just targetPath ->
                       do
@@ -119,7 +118,7 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
                                     sourceMod
                                       & Src._values
                                       & findFirstValueNamed name
-                              print "getting there"
+                              debug "getting there"
                               pure
                                 ( case finalResult of
                                     Nothing -> Json.Encode.null
@@ -138,12 +137,12 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
                                 )
                           Left err ->
                             do
-                              print err
+                              debug $ show err
                               pure (encodeSearchResult found)
         FoundPattern _ ->
           do
-            print "Found a patter, but who cares really?"
-            print found
+            debug "Found a pattern, but who cares really?"
+            debug $ show found
 
             pure (encodeSearchResult found)
 


### PR DESCRIPTION
## Problem
The core compiler uses functions such as `putStrLn`, `putStrFlush`, `hPutStr`, and `Text.PrettyPrint.ANSI.Leijen.displayIO` to print to `stdout` and `stderr` as it compiles, downloads dependencies, displays errors, etc. 

Also, the `Watchtower.Find` module uses `print`.

Running these functions without a lock can create garbled output, which can have very undesirable consequences, such as having your computer beep at you or open Print dialogs 🙃 

## Solution
Use `Ext.Common.debug` instead of `putStrLn` (et al), and introduce `Ext.Common.withPrintLockIfDebug` to wrap calls to `Text.PrettyPrint.ANSI.Leijen` so that its `IO` is performed atomically.