### PR TITLE
Fix `FindDefinition` position matching

### DIFF
--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -242,7 +242,7 @@ findFirstJust fn vals =
 
 withinRegion :: A.Position -> A.Region -> Bool
 withinRegion (A.Position row col) (A.Region (A.Position startRow startCol) (A.Position endRow endCol)) =
-  row >= startRow && row <= endRow
+  ((row == startRow && col >= startCol) || row > startRow) && ((row == endRow && col <= endCol) || row < endRow)
 
 {- Searching a Can.AST -}
 

--- a/watchtower-frontends/vscode/src/watchtower.ts
+++ b/watchtower-frontends/vscode/src/watchtower.ts
@@ -379,8 +379,8 @@ export class ElmDefinitionProvider implements vscode.DefinitionProvider {
       Question.ask(
         Question.questions.findDefinition(
           document.uri.fsPath,
-          position.line,
-          position.character
+          position.line + 1,
+          position.character + 1
         ),
         (resp) => {
           log.log("FOUND DEFINITION!");


### PR DESCRIPTION
This PR fixes two issues that make the server match the wrong nodes on the AST:

- When we request the definition for a position from VSC, we are not adjusting the 0-based positions we get from the Extensions API to Elm's 1-based positions. 

- `Watchtower.Find.withinRegion` ignores the column of the `Position` and `Region` completely

Note: We are already adjusting the 1-based positions from elm-dev to VSC's 0-based when we get a match to jump to. Just not when we ask for them.