### PR TITLE
Find names in local scope

### DIFF
--- a/example/src/Test/Basic.elm
+++ b/example/src/Test/Basic.elm
@@ -1,5 +1,6 @@
 module Test.Basic exposing (..)
 
+import Html
 import Test.Module
 
 
@@ -36,6 +37,18 @@ type Reason
     | Invalid InvalidReason
 
 
+reasonToString reason =
+    case reason of
+        Custom ->
+            "custom"
+
+        Equality a b ->
+            a ++ "=" ++ b
+
+        _ ->
+            "Not implemented"
+
+
 type InvalidReason
     = EmptyList
     | NonpositiveFuzzCount
@@ -67,3 +80,25 @@ addOne x =
 suite =
     test "addOne adds one" <|
         equals (addOne 123) 124
+
+
+view user age friends =
+    let
+        { first, last } =
+            user
+
+        friendsView =
+            Html.ul []
+                << List.map
+                    (\( friendFirst, friendLast ) ->
+                        Html.li []
+                            [ Html.text friendFirst
+                            , Html.text friendLast
+                            ]
+                    )
+    in
+    Html.div []
+        [ Html.h1 [] [ Html.text (first ++ " " ++ last) ]
+        , Html.p [] [ Html.text (String.fromInt age) ]
+        , friendsView friends
+        ]

--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Watchtower.Find
-  ( definitionAndPrint,
+  ( definition,
   )
 where
 
@@ -50,23 +50,8 @@ import qualified Watchtower.Details
 
 {- Find Definition -}
 
--- |
---  Given file name and coords (line and char)
---  1. Find which name is at the coordinates
---
---  2. Resolve definition source
---
---    2.a Qualified call
---        -> resolve Qualification to full module name
---        -> resolve full module name to file path
---        -> read file, get coordinates of definition
---
---    2.b Unqualified call
---        -> Check variables in local scope
---        -> Else, check top level values in file
---        -> Else, check interface for modules with exposed values
-definitionAndPrint :: FilePath -> Watchtower.Details.PointLocation -> IO Json.Encode.Value
-definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
+definition :: FilePath -> Watchtower.Details.PointLocation -> IO Json.Encode.Value
+definition root (Watchtower.Details.PointLocation path point) = do
   Right (Compile.Artifacts modul typeMap localGraph) <- 
     Ext.CompileProxy.loadSingleArtifacts root path
 

--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -88,6 +88,7 @@ definitionAndPrint root (Watchtower.Details.PointLocation path point) = do
       fail "not implemented"
 
 
+findLocatedValue :: FilePath -> LocatedValue -> IO Json.Encode.Value
 findLocatedValue root located =
   case located of 
     Local localName -> do

--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -261,7 +261,7 @@ defNamePattern def =
       A.At region $ Can.PVar name
 
 
-findExpr :: A.Position -> [Can.Pattern] -> Can.Expr  -> SearchResult
+findExpr :: A.Position -> [Can.Pattern] -> Can.Expr -> SearchResult
 findExpr point foundPatterns expr@(A.At region expr_) =
   if withinRegion point region
     then case refineMatch point foundPatterns expr_ of

--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -336,8 +336,12 @@ refineMatch point foundPatterns expr_ =
         & orFind (extendAndDive [pattern]) two
 
     Can.Case expr branches ->
-        dive expr
-      -- TODO: check branches too!
+        dive expr 
+          & orFind (
+              findFirstInList $
+                \(Can.CaseBranch pattern expr) -> 
+                  extendAndDive [pattern] expr
+            ) branches
     
     Can.Access expr locatedName ->
       dive expr
@@ -510,7 +514,7 @@ findFirstCtorNamed name =
 
 findFirstPatternIntroducing :: Name.Name -> [Can.Pattern] -> Maybe Can.Pattern
 findFirstPatternIntroducing name =
-  findFirstJust (findFirstPatternIntroducing name)
+  findFirstJust (findPatternIntroducing name)
 
 
 findPatternIntroducing :: Name.Name -> Can.Pattern -> Maybe Can.Pattern
@@ -555,4 +559,4 @@ findPatternIntroducing name (pattern@(A.At _ pattern_)) =
 
   inList  =
     findFirstJust (findPatternIntroducing name)
-
+    

--- a/ext-watchtower/Watchtower/Questions.hs
+++ b/ext-watchtower/Watchtower/Questions.hs
@@ -294,7 +294,7 @@ ask state question =
                 f
        in do
             root <- fmap (Maybe.fromMaybe ".") (Watchtower.Live.getRoot path state)
-            Watchtower.Find.definitionAndPrint root location
+            Watchtower.Find.definition root location
               & fmap Json.Encode.encodeUgly
 
     FindAllInstancesPlease location ->

--- a/watchtower-frontends/vscode/src/watchtower.ts
+++ b/watchtower-frontends/vscode/src/watchtower.ts
@@ -13,9 +13,9 @@ type Msg =
   | { msg: "Discover"; details: String }
   | { msg: "Changed"; details: { path: String } }
   | {
-      msg: "Watched";
-      details: { path: String; warnings: Boolean; docs: Boolean }[];
-    };
+    msg: "Watched";
+    details: { path: String; warnings: Boolean; docs: Boolean }[];
+  };
 
 const discover = (roots: String): Msg => {
   return { msg: "Discover", details: roots };
@@ -47,19 +47,19 @@ type Project = {
 function socketConnect(options) {
   const websocket = new WebSocketClient();
 
-  websocket.on("connectFailed", function (error) {
+  websocket.on("connectFailed", function(error) {
     log.log("Connect Error: " + error.toString());
     options.onConnectionFailed(error);
   });
 
-  websocket.on("connect", function (connection) {
-    connection.on("error", function (error) {
+  websocket.on("connect", function(connection) {
+    connection.on("error", function(error) {
       log.log("Connection Error: " + error.toString());
     });
-    connection.on("close", function () {
+    connection.on("close", function() {
       log.log("Connection Closed");
     });
-    connection.on("message", function (message) {
+    connection.on("message", function(message) {
       if (message.type === "utf8") {
         options.receive(message.utf8Data);
       }
@@ -161,7 +161,7 @@ export class Watchtower {
 
   private onConnectionFailed(error) {
     const self = this;
-    this.retry = setTimeout(function () {
+    this.retry = setTimeout(function() {
       log.log("Reattempting connection");
       socketConnect({
         url: Question.urls.websocket,
@@ -368,7 +368,7 @@ function prepareRanges(ranges) {
 // Definition Provider
 
 export class ElmDefinitionProvider implements vscode.DefinitionProvider {
-  constructor() {}
+  constructor() { }
   public provideDefinition(
     document: vscode.TextDocument,
     position: vscode.Position,
@@ -383,8 +383,6 @@ export class ElmDefinitionProvider implements vscode.DefinitionProvider {
           position.character + 1
         ),
         (resp) => {
-          log.log("FOUND DEFINITION!");
-          log.log(JSON.stringify(resp));
           if (!resp) {
             resolve(null);
           } else {
@@ -398,7 +396,7 @@ export class ElmDefinitionProvider implements vscode.DefinitionProvider {
             resolve(new vscode.Location(uri, new vscode.Range(start, end)));
           }
         },
-        (err) => {}
+        reject
       );
     });
   }

--- a/watchtower-frontends/vscode/src/watchtower.ts
+++ b/watchtower-frontends/vscode/src/watchtower.ts
@@ -13,9 +13,9 @@ type Msg =
   | { msg: "Discover"; details: String }
   | { msg: "Changed"; details: { path: String } }
   | {
-    msg: "Watched";
-    details: { path: String; warnings: Boolean; docs: Boolean }[];
-  };
+      msg: "Watched";
+      details: { path: String; warnings: Boolean; docs: Boolean }[];
+    };
 
 const discover = (roots: String): Msg => {
   return { msg: "Discover", details: roots };
@@ -47,19 +47,19 @@ type Project = {
 function socketConnect(options) {
   const websocket = new WebSocketClient();
 
-  websocket.on("connectFailed", function(error) {
+  websocket.on("connectFailed", function (error) {
     log.log("Connect Error: " + error.toString());
     options.onConnectionFailed(error);
   });
 
-  websocket.on("connect", function(connection) {
-    connection.on("error", function(error) {
+  websocket.on("connect", function (connection) {
+    connection.on("error", function (error) {
       log.log("Connection Error: " + error.toString());
     });
-    connection.on("close", function() {
+    connection.on("close", function () {
       log.log("Connection Closed");
     });
-    connection.on("message", function(message) {
+    connection.on("message", function (message) {
       if (message.type === "utf8") {
         options.receive(message.utf8Data);
       }
@@ -161,7 +161,7 @@ export class Watchtower {
 
   private onConnectionFailed(error) {
     const self = this;
-    this.retry = setTimeout(function() {
+    this.retry = setTimeout(function () {
       log.log("Reattempting connection");
       socketConnect({
         url: Question.urls.websocket,
@@ -368,7 +368,7 @@ function prepareRanges(ranges) {
 // Definition Provider
 
 export class ElmDefinitionProvider implements vscode.DefinitionProvider {
-  constructor() { }
+  constructor() {}
   public provideDefinition(
     document: vscode.TextDocument,
     position: vscode.Position,


### PR DESCRIPTION
Currently, we are only able to find the definition of top-level values. This PR closes the gap by making it possible to find the definition of every name available in an expression's scope:

<img width="500" src="https://user-images.githubusercontent.com/1724813/200398034-22ac290c-8e74-41d0-97db-7c59c7545911.gif">

I didn't include it in the GIF, but you can also find names captured with pattern matching on type constructors.
