### PR TITLE
Find type constructors used in pattern matching

### DIFF
--- a/ext-watchtower/Watchtower/Find.hs
+++ b/ext-watchtower/Watchtower/Find.hs
@@ -76,20 +76,6 @@ definition root (Watchtower.Details.PointLocation path point) = do
     FoundPattern _ ->
       pure Json.Encode.null
   where
-    encodeResult path result =
-      case result of
-        Nothing ->
-          Json.Encode.null
-        Just (A.At region _) ->
-          Json.Encode.object
-            [ ( "definition",
-                Json.Encode.object
-                  [ ("region", Watchtower.Details.encodeRegion region),
-                    ("path", Json.Encode.string (Json.String.fromChars path))
-                  ]
-              )
-            ]
-
     findExternalWith findFn name listAccess canMod = do
       details <- Ext.CompileProxy.loadProject
 


### PR DESCRIPTION
Make it possible to find the definition of a type constructor referenced when pattern matching: 

<img width="500" src="https://user-images.githubusercontent.com/1724813/200399605-4ac1a981-30c4-45df-8b42-75fb95ee2a87.gif">

This works on function arguments, case..of, let..in, and nested patterns like `Just ( Invalid EmptyList, _ )`. 