### PR TITLE
Port GHC 9.2 upgrades from Lamdera

### DIFF
--- a/compiler/src/Data/Name.hs
+++ b/compiler/src/Data/Name.hs
@@ -241,7 +241,7 @@ fromTypeVariable name@(Utf8.Utf8 ba#) index =
   else
     let
       len# = sizeofByteArray# ba#
-      end# = indexWord8Array# ba# (len# -# 1#)
+      end# = word8ToWord# (indexWord8Array# ba# (len# -# 1#))
     in
     if isTrue# (leWord# 0x30## end#) && isTrue# (leWord# end# 0x39##) then
       runST
@@ -316,11 +316,11 @@ fromManyNames names =
         ST $ \s ->
           case newByteArray# (len# +# 3#) s of
             (# s, mba# #) ->
-              case writeWord8Array# mba# 0# 0x5F## {-_-} s of
+              case writeWord8Array# mba# 0# (wordToWord8# 0x5F##) {-_-} s of
                 s ->
-                  case writeWord8Array# mba# 1# 0x4D## {-M-} s of
+                  case writeWord8Array# mba# 1# (wordToWord8# 0x4D##) {-M-} s of
                     s ->
-                      case writeWord8Array# mba# 2# 0x24## {-$-} s of
+                      case writeWord8Array# mba# 2# (wordToWord8# 0x24##) {-$-} s of
                         s ->
                           case copyByteArray# ba# 0# mba# 3# len# s of
                             s ->

--- a/compiler/src/Data/Utf8.hs
+++ b/compiler/src/Data/Utf8.hs
@@ -109,10 +109,10 @@ contains (W8# word#) (Utf8 ba#) =
   containsHelp word# ba# 0# (sizeofByteArray# ba#)
 
 
-containsHelp :: Word# -> ByteArray# -> Int# -> Int# -> Bool
+containsHelp :: Word8# -> ByteArray# -> Int# -> Int# -> Bool
 containsHelp word# ba# !offset# len# =
   if isTrue# (offset# <# len#) then
-    if isTrue# (eqWord# word# (indexWord8Array# ba# offset#))
+    if isTrue# (eqWord8# word# (indexWord8Array# ba# offset#))
       then True
       else containsHelp word# ba# (offset# +# 1#) len#
   else
@@ -145,7 +145,7 @@ startsWithChar isGood bytes@(Utf8 ba#) =
     False
   else
     let
-      !w# = indexWord8Array# ba# 0#
+      !w# = word8ToWord# (indexWord8Array# ba# 0#)
       !char
         | isTrue# (ltWord# w# 0xC0##) = C# (chr# (word2Int# w#))
         | isTrue# (ltWord# w# 0xE0##) = chr2 ba# 0# w#
@@ -164,7 +164,7 @@ endsWithWord8 (W8# w#) (Utf8 ba#) =
   let len# = sizeofByteArray# ba# in
   isTrue# (len# ># 0#)
   &&
-  isTrue# (eqWord# w# (indexWord8Array# ba# (len# -# 1#)))
+  isTrue# (eqWord8# w# (indexWord8Array# ba# (len# -# 1#)))
 
 
 
@@ -186,11 +186,11 @@ splitHelp str start offsets =
       unsafeSlice str start offset : splitHelp str (offset + 1) offsets
 
 
-findDividers :: Word# -> ByteArray# -> Int# -> Int# -> [Int] -> [Int]
+findDividers :: Word8# -> ByteArray# -> Int# -> Int# -> [Int] -> [Int]
 findDividers divider# ba# !offset# len# revOffsets =
   if isTrue# (offset# <# len#) then
     findDividers divider# ba# (offset# +# 1#) len# $
-      if isTrue# (eqWord# divider# (indexWord8Array# ba# offset#))
+      if isTrue# (eqWord8# divider# (indexWord8Array# ba# offset#))
       then I# offset# : revOffsets
       else revOffsets
   else
@@ -351,7 +351,7 @@ toCharsHelp ba# offset# len# =
     []
   else
     let
-      !w# = indexWord8Array# ba# offset#
+      !w# = word8ToWord# (indexWord8Array# ba# offset#)
       !(# char, width# #)
         | isTrue# (ltWord# w# 0xC0##) = (# C# (chr# (word2Int# w#)), 1# #)
         | isTrue# (ltWord# w# 0xE0##) = (# chr2 ba# offset# w#, 2# #)
@@ -368,7 +368,7 @@ chr2 :: ByteArray# -> Int# -> Word# -> Char
 chr2 ba# offset# firstWord# =
   let
     !i1# = word2Int# firstWord#
-    !i2# = word2Int# (indexWord8Array# ba# (offset# +# 1#))
+    !i2# = word8ToInt# (indexWord8Array# ba# (offset# +# 1#))
     !c1# = uncheckedIShiftL# (i1# -# 0xC0#) 6#
     !c2# = i2# -# 0x80#
   in
@@ -380,8 +380,8 @@ chr3 :: ByteArray# -> Int# -> Word# -> Char
 chr3 ba# offset# firstWord# =
   let
     !i1# = word2Int# firstWord#
-    !i2# = word2Int# (indexWord8Array# ba# (offset# +# 1#))
-    !i3# = word2Int# (indexWord8Array# ba# (offset# +# 2#))
+    !i2# = word8ToInt# (indexWord8Array# ba# (offset# +# 1#))
+    !i3# = word8ToInt# (indexWord8Array# ba# (offset# +# 2#))
     !c1# = uncheckedIShiftL# (i1# -# 0xE0#) 12#
     !c2# = uncheckedIShiftL# (i2# -# 0x80#) 6#
     !c3# = i3# -# 0x80#
@@ -394,9 +394,9 @@ chr4 :: ByteArray# -> Int# -> Word# -> Char
 chr4 ba# offset# firstWord# =
   let
     !i1# = word2Int# firstWord#
-    !i2# = word2Int# (indexWord8Array# ba# (offset# +# 1#))
-    !i3# = word2Int# (indexWord8Array# ba# (offset# +# 2#))
-    !i4# = word2Int# (indexWord8Array# ba# (offset# +# 3#))
+    !i2# = word8ToInt# (indexWord8Array# ba# (offset# +# 1#))
+    !i3# = word8ToInt# (indexWord8Array# ba# (offset# +# 2#))
+    !i4# = word8ToInt# (indexWord8Array# ba# (offset# +# 3#))
     !c1# = uncheckedIShiftL# (i1# -# 0xF0#) 18#
     !c2# = uncheckedIShiftL# (i2# -# 0x80#) 12#
     !c3# = uncheckedIShiftL# (i3# -# 0x80#) 6#
@@ -404,6 +404,10 @@ chr4 ba# offset# firstWord# =
   in
   C# (chr# (c1# +# c2# +# c3# +# c4#))
 
+
+word8ToInt# :: Word8# -> Int#
+word8ToInt# word8 =
+  word2Int# (word8ToWord# word8)
 
 
 -- TO BUILDER
@@ -471,7 +475,7 @@ toEscapedBuilderHelp before after !name@(Utf8 ba#) k =
 escape :: Word8 -> Word8 -> Ptr a -> Utf8 t -> Int -> Int -> Int -> IO ()
 escape before@(W8# before#) after ptr name@(Utf8 ba#) offset@(I# offset#) len@(I# len#) i@(I# i#) =
   if isTrue# (i# <# len#) then
-    if isTrue# (eqWord# before# (indexWord8Array# ba# (offset# +# i#)))
+    if isTrue# (eqWord8# before# (indexWord8Array# ba# (offset# +# i#)))
     then
       do  writeWordToPtr ptr i after
           escape before after ptr name offset len (i + 1)

--- a/compiler/src/Parse/Variable.hs
+++ b/compiler/src/Parse/Variable.hs
@@ -21,7 +21,7 @@ import qualified Data.Name as Name
 import qualified Data.Set as Set
 import Data.Word (Word8)
 import Foreign.Ptr (Ptr, plusPtr)
-import GHC.Exts (Char(C#), Int#, (+#), (-#), chr#, uncheckedIShiftL#, word2Int#)
+import GHC.Exts (Char(C#), Int#, (+#), (-#), chr#, uncheckedIShiftL#, word2Int#, word8ToWord#)
 import GHC.Word (Word8(W8#))
 
 import qualified AST.Source as Src
@@ -384,4 +384,4 @@ chr4 pos firstWord =
 
 unpack :: Word8 -> Int#
 unpack (W8# word#) =
-  word2Int# word#
+  word2Int# (word8ToWord# word#)

--- a/ext-dev/StandaloneInstances.hs
+++ b/ext-dev/StandaloneInstances.hs
@@ -409,13 +409,7 @@ instance Show a => Show (MVar.MVar a) where
 
 deriving instance Show Deps.Registry.KnownVersions
 
-
 deriving instance Show Json.Encode.Value
-
-instance Show B.Builder where
-  show = T.unpack . T.decodeUtf8 . BSL.toStrict . B.toLazyByteString
-
-
 
 deriving instance Show Elm.Details.Local
 
@@ -437,7 +431,7 @@ instance IsString Json.String.String where
 instance IsString Elm.String.String where
   fromString = Utf8.fromChars
 
-deriving instance Show Build.Root 
+deriving instance Show Build.Root
 
 
 

--- a/ext-sentry/Ext/Filewatch.hs
+++ b/ext-sentry/Ext/Filewatch.hs
@@ -45,18 +45,24 @@ watch root action =
 toString :: System.FSNotify.Event -> String
 toString event =
   case event of
-    System.FSNotify.Added filepath _ _ -> "Added " <> System.FilePath.takeFileName filepath
-    System.FSNotify.Modified filepath _ _ -> "Modified " <> System.FilePath.takeFileName filepath
-    System.FSNotify.Removed filepath _ _ -> "Removed " <> System.FilePath.takeFileName filepath
-    System.FSNotify.Unknown filepath _ _ -> "Unknown " <> System.FilePath.takeFileName filepath
+    System.FSNotify.Added filepath _ _                   -> "Added " <> System.FilePath.takeFileName filepath
+    System.FSNotify.Modified filepath _ _                -> "Modified " <> System.FilePath.takeFileName filepath
+    System.FSNotify.ModifiedAttributes filepath _ _      -> "ModifiedAttributes " <> System.FilePath.takeFileName filepath
+    System.FSNotify.Removed filepath _ _                 -> "Removed " <> System.FilePath.takeFileName filepath
+    System.FSNotify.WatchedDirectoryRemoved filepath _ _ -> "WatchedDirectoryRemoved" <> System.FilePath.takeFileName filepath
+    System.FSNotify.CloseWrite filepath _ _              -> "CloseWrite" <> System.FilePath.takeFileName filepath
+    System.FSNotify.Unknown filepath _ _ _               -> "Unknown " <> System.FilePath.takeFileName filepath
 
 getEventFilePath :: System.FSNotify.Event -> FilePath
 getEventFilePath event =
   case event of
-    System.FSNotify.Added filepath _ _ -> filepath
-    System.FSNotify.Modified filepath _ _ -> filepath
-    System.FSNotify.Removed filepath _ _ -> filepath
-    System.FSNotify.Unknown filepath _ _ -> filepath
+    System.FSNotify.Added filepath _ _                   -> filepath
+    System.FSNotify.Modified filepath _ _                -> filepath
+    System.FSNotify.ModifiedAttributes filepath _ _      -> filepath
+    System.FSNotify.Removed filepath _ _                 -> filepath
+    System.FSNotify.WatchedDirectoryRemoved filepath _ _ -> filepath
+    System.FSNotify.CloseWrite filepath _ _              -> filepath
+    System.FSNotify.Unknown filepath _ _ _               -> filepath
 
 
 shouldTrigger :: System.FSNotify.Event -> Bool

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,21 +1,42 @@
-resolver: lts-19.31 # ghc-9.0.2
+resolver: lts-20.26 # ghc 9.2.8
+system-ghc: false
+ghc-options:
+  "$locals": -Wincomplete-patterns -lstdc++
+  "$targets": -lstdc++
 allow-newer: true
-local-bin-path: dist
 extra-deps:
-- snap-server-1.1.2.0@sha256:325378e4f7a50b1a94cf6175e11b9ac6db5edcdd87226f2d5997999334b85c46,15200
-- websockets-snap-0.10.3.1@sha256:89582b7db916e67b6c8192f489e4eafe7488d9f813e349836a2e74fa4388623d,991
-- io-streams-haproxy-1.0.1.0@sha256:2241a754697935e0a11e814affcaa4861b42fe88131f807b586ef48051e28a08,3070
-- regex-posix-clib-2.7 # Required to build on windows
+- timeout-0.1.1
+- command-0.1.1
+- snap-server-1.1.2.1
+- websockets-snap-0.10.3.1
+- fold-debounce-0.2.0.11
+- snap-core-1.0.5.1
+- readable-0.3.1
+- fsnotify-0.4.1.0
 
+# Required to build on windows
+- regex-posix-0.96.0.1
+
+# windows pinning for build issues
+- ansi-terminal-0.11
+- git: https://github.com/noteed/language-glsl.git
+  commit: 99c3aae76363b127679da640a6f00d61d2203830
+# Metapackage that apparently resolves below issues for windows:
 flags:
   regex-posix:
-    _regex-posix-clib: true
-
+     _regex-posix-clib: true
 packages:
-- "."
+- '.'
 
-extra-include-dirs: # Try remove this in 9.3.2 as it should be fixed: https://gitlab.haskell.org/ghc/ghc/-/issues/20592#note_436353
-# This should be a system agnostic path to macos FFI libs, if not working for you try find a valid path with these bash commands:
-# dir=`xcrun --show-sdk-path`/usr/include/ffi && ls -alh $dir && echo $dir
-# dir=`pkg-config --cflags libffi | sed -E "s/^-I//"` && ls -alh $dir && echo $dir
-- /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/ffi
+
+# Need to re-check if the below is still an issue now we're on GHC 9.4:
+# > The system-cxx-std-lib metapackage should significantly improve the status quo here and is shipped with GHC %9.4.1. Closing.
+# ---------------
+# https://gitlab.haskell.org/ghc/ghc/-/issues/20010#note_359766
+# however extra-libraries is not a supported stack.yaml field...?
+# extra-libraries: stdc++ supc++ gcc_s
+
+# And for windows build issues related to .ddl inclusion
+# https://discourse.haskell.org/t/announce-ghcup-0-1-15-rc2-windows-pre-release/2616/14
+# however it seems stack automatically includes a bunch of paths, don't think this helped?
+# - C:\ghcup\msys64\mingw64\include

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,36 +5,89 @@
 
 packages:
 - completed:
-    hackage: snap-server-1.1.2.0@sha256:325378e4f7a50b1a94cf6175e11b9ac6db5edcdd87226f2d5997999334b85c46,15200
+    hackage: timeout-0.1.1@sha256:56c1d3321d7139d1f7ebf04d46c95d3a3f1c8c9e0f15666ae3ccd6bae6204b6e,1427
     pantry-tree:
-      sha256: bac856da3319ff93d100dfd5811fbcc39d7d8b7e51d6adc07aea3fc81aacd14e
+      sha256: e571503d7e609c3fe496de7e858613360bfa6c06e20ac57d9659bd32d0645889
+      size: 437
+  original:
+    hackage: timeout-0.1.1
+- completed:
+    hackage: command-0.1.1@sha256:5232b98c195bc3b8a6f35c55ccd2fa424abe355ca54cfcd836bbe7e494834773,1110
+    pantry-tree:
+      sha256: 1ecfeb4b1367de6b489dbda20be05df78beb07f71d7c0b1f471fab1cd9c8044a
+      size: 167
+  original:
+    hackage: command-0.1.1
+- completed:
+    hackage: snap-server-1.1.2.1@sha256:8ea05b9b068c1e86be77073107eadc177d7eec93724963c063877478a062b229,15471
+    pantry-tree:
+      sha256: ddeae933a2dfb19eebe466b1be5014b002154f18624e654086b13fe4bb56c0fd
       size: 3313
   original:
-    hackage: snap-server-1.1.2.0@sha256:325378e4f7a50b1a94cf6175e11b9ac6db5edcdd87226f2d5997999334b85c46,15200
+    hackage: snap-server-1.1.2.1
 - completed:
-    hackage: websockets-snap-0.10.3.1@sha256:89582b7db916e67b6c8192f489e4eafe7488d9f813e349836a2e74fa4388623d,991
+    hackage: websockets-snap-0.10.3.1@sha256:1e52d1b67eaa54e4c5e66e84fc22e9a2ca41bf9930ea2c94b8ec11e4080d3f23,1042
     pantry-tree:
-      sha256: 1630fc5df984c0fd574e68860bf21e1ea3f60ffc26ed1f3859d4e5411bc1e6d8
-      size: 330
+      sha256: 14aa753981ac0c8465d0d18ea84f0b1414d6e7a6232d47958e61b1d04e227f16
+      size: 331
   original:
-    hackage: websockets-snap-0.10.3.1@sha256:89582b7db916e67b6c8192f489e4eafe7488d9f813e349836a2e74fa4388623d,991
+    hackage: websockets-snap-0.10.3.1
 - completed:
-    hackage: io-streams-haproxy-1.0.1.0@sha256:2241a754697935e0a11e814affcaa4861b42fe88131f807b586ef48051e28a08,3070
+    hackage: fold-debounce-0.2.0.11@sha256:948b0ec836a62c5207c3caac5a9f15fa483cdca8cbe1d50cadb1bc03803bbb3f,2305
     pantry-tree:
-      sha256: e0fd63710948210cda2b5d21bd51eedc43f8813470d015158de8bd03237b1cb9
-      size: 589
+      sha256: 3bba10d8fca5a1e4d426f1c5cf0f6ff408240e9f9d3308499570acd5d5413fd0
+      size: 451
   original:
-    hackage: io-streams-haproxy-1.0.1.0@sha256:2241a754697935e0a11e814affcaa4861b42fe88131f807b586ef48051e28a08,3070
+    hackage: fold-debounce-0.2.0.11
 - completed:
-    hackage: regex-posix-clib-2.7@sha256:998fca06da3d719818f0691ef0b8b9b7375afeea228cb08bd9e2db53f96b0cd7,1232
+    hackage: snap-core-1.0.5.1@sha256:e84e14c59ef925cf83312103449e4253800489d051991675b747ee5bcc6dda4e,9502
     pantry-tree:
-      sha256: 5bf20952472d930323766d250f5fbbe3fe6f2cd3d931e5cf7b62a238ab2099ff
-      size: 524
+      sha256: 58715afcb05dfac897b3a4ab3dd8e34f99f17c65d470f589202ef62ead8453ca
+      size: 3429
   original:
-    hackage: regex-posix-clib-2.7
+    hackage: snap-core-1.0.5.1
+- completed:
+    hackage: readable-0.3.1@sha256:ea550740bbee9ae46c6bbf1c5e5185818a1d37509b855c640b0a7f2dfba6dc37,1121
+    pantry-tree:
+      sha256: a93d2c4e208cf064a8b1e8087d7a8ea77c263115e7ba18f3ef6abe935548faca
+      size: 313
+  original:
+    hackage: readable-0.3.1
+- completed:
+    hackage: fsnotify-0.4.1.0@sha256:44540beabea36aeeef930aa4d5f28091d431904bc9923b6ac4d358831c651235,2854
+    pantry-tree:
+      sha256: f8e89e81fe0ca6e285036e04b165119ccfc59e7e668c1bfc28927f39062c5949
+      size: 1280
+  original:
+    hackage: fsnotify-0.4.1.0
+- completed:
+    hackage: regex-posix-0.96.0.1@sha256:816d6acc560cb86672f347a7bef8129578dde26ed760f9e79b4976ed9bd7b9fd,2925
+    pantry-tree:
+      sha256: ea6a3adfad8fb41a761b71afb057454a41eb76fc3f75c926d0bda90588b20529
+      size: 748
+  original:
+    hackage: regex-posix-0.96.0.1
+- completed:
+    hackage: ansi-terminal-0.11@sha256:97470250c92aae14c4c810d7f664c532995ba8910e2ad797b29f22ad0d2d0194,3307
+    pantry-tree:
+      sha256: 4098c4b8bb503fcf0730aedc8247a479d3e22fd1fe4c6b4b2b2b5da30bdfb713
+      size: 1461
+  original:
+    hackage: ansi-terminal-0.11
+- completed:
+    commit: 99c3aae76363b127679da640a6f00d61d2203830
+    git: https://github.com/noteed/language-glsl.git
+    name: language-glsl
+    pantry-tree:
+      sha256: 155d01f395cc7df3c511df6ff35835b9d54f88a629a58098af7b54a4eeff8e63
+      size: 1066
+    version: 0.4.0.0
+  original:
+    commit: 99c3aae76363b127679da640a6f00d61d2203830
+    git: https://github.com/noteed/language-glsl.git
 snapshots:
 - completed:
-    sha256: e5f56f619132209b826084cacd6374d7f0344cc88a9d1d305878190e4204ae1f
-    size: 619205
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/31.yaml
-  original: lts-19.31
+    sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2
+    size: 650475
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/26.yaml
+  original: lts-20.26


### PR DESCRIPTION
Some hard-won figuring-outs with 💜 from Lamdera.

Going further to GHC 9.4 has proved too challenging so far (results in `linux-arm64` and `windows-x86` build failures) but at least with 9.2 we get improved native macos M1 compilation support and the `Word` changes to keep up with recent Elm upstream updates.