### PR TITLE
Run elm-dev via shell from vscode extension

### DIFF
--- a/apps/vscode/src/lsp.ts
+++ b/apps/vscode/src/lsp.ts
@@ -45,8 +45,8 @@ export async function startLanguageServer(context: vscode.ExtensionContext): Pro
 
     // Let the language client spawn the server as an executable using stdio transport
     const serverOptions: ServerOptions = {
-      run: { command: 'elm-dev', args: ['lsp'], options: { env: process.env } },
-      debug: { command: 'elm-dev', args: ['lsp'], options: { env: process.env } },
+      run: { command: 'elm-dev', args: ['lsp'], options: { env: process.env, shell: true } },
+      debug: { command: 'elm-dev', args: ['lsp'], options: { env: process.env, shell: true } },
     };
 
     const clientOptions: LanguageClientOptions = {


### PR DESCRIPTION
This allows Windows to find the elm-dev.cmd npm shim

re: https://discord.com/channels/534524278847045633/1435630482950717470/1435643683440562257